### PR TITLE
Fix key and value parameters in AddOrUpdate method

### DIFF
--- a/src/MimeTypesMap/MimeTypesMap.cs
+++ b/src/MimeTypesMap/MimeTypesMap.cs
@@ -807,7 +807,7 @@ namespace HeyRed.Mime
 
         public static void AddOrUpdate(string mime, string extension)
         {
-            _mimeTypeMap.Value[mime] = extension;
+            _mimeTypeMap.Value[extension] = mime;
         }
     }
 }

--- a/test/MimeTypesMapTests/SimpleTests.cs
+++ b/test/MimeTypesMapTests/SimpleTests.cs
@@ -25,5 +25,18 @@ namespace MimeTypesMapTests
             var ext = MimeTypesMap.GetExtension("image/jpeg");
             Assert.Equal("jpeg", ext);
         }
+
+        
+        [Fact]
+        public void AddOrUpdate()
+        {
+            var ext = "ext";
+            var mimeToAdd = "test/ext";
+
+            MimeTypesMap.AddOrUpdate(mimeToAdd, ext);
+            var mimeResult = MimeTypesMap.GetMimeType("file.ext");
+
+            Assert.Equal(mimeToAdd, mimeResult);
+        }
     }
 }


### PR DESCRIPTION
In `AddOrUpdate` method currently mime type is used as a key in a dictionary which is indexed by extension string. This PR is fixing this. 