### PR TITLE
Enable uppercase file extensions

### DIFF
--- a/src/MimeTypesMap/MimeTypesMap.cs
+++ b/src/MimeTypesMap/MimeTypesMap.cs
@@ -1014,7 +1014,7 @@ namespace HeyRed.Mime
             var ind = ext.LastIndexOf('.');
             if (ind != -1 && ext.Length > ind + 1)
             {
-                ext = fileName.Substring(ind + 1);
+                ext = fileName.Substring(ind + 1).ToLower();
             }
             if (_mimeTypeMap.Value.TryGetValue(ext, out string result))
             {

--- a/src/MimeTypesMap/MimeTypesMap.tt
+++ b/src/MimeTypesMap/MimeTypesMap.tt
@@ -44,7 +44,7 @@ namespace HeyRed.Mime
             var ind = ext.LastIndexOf('.');
             if (ind != -1 && ext.Length > ind + 1)
             {
-                ext = fileName.Substring(ind + 1);
+                ext = fileName.Substring(ind + 1).ToLower();
             }
             if (_mimeTypeMap.Value.TryGetValue(ext, out string result))
             {


### PR DESCRIPTION
Right now, the script returns octet stream, if the file extension is written in uppercase.