### PR TITLE
 Add .NET Standard 2.0 target framework

### DIFF
--- a/src/MimeTypesMap/MimeTypesMap.csproj
+++ b/src/MimeTypesMap/MimeTypesMap.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Simple dictionary provides a few methods to lookup mime type/extension, generated From Apache's mime.types.</Description>
     <Authors>red</Authors>
-    <TargetFrameworks>netstandard1.3;net45;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net40</TargetFrameworks>
     <AssemblyName>MimeTypesMap</AssemblyName>
     <AssemblyOriginatorKeyFile>../../key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/MimeTypesMapTests/MimeTypesMapTests.csproj
+++ b/test/MimeTypesMapTests/MimeTypesMapTests.csproj
@@ -6,10 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Simplifying the dependency graph, as per [which .NET Standard version to target](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#which-net-standard-version-to-target), specifically:
> However, targeting lower .NET Standard versions introduces a number of support dependencies. If your project targets .NET Standard 1.x, we recommend that you also target .NET Standard 2.0. This simplifies the dependency graph for users of your library that run on .NET Standard 2.0 compatible frameworks, and it reduces the number of packages they need to download.