### PR TITLE
Added type text/rtf

### DIFF
--- a/src/MimeTypesMap/MimeTypesMap.cs
+++ b/src/MimeTypesMap/MimeTypesMap.cs
@@ -888,7 +888,7 @@ namespace HeyRed.Mime
             ["in"] = "text/plain",
             ["dsc"] = "text/prs.lines.tag",
             ["rtx"] = "text/richtext",
-			["rtf"] = "text/rtf",
+            ["rtf"] = "text/rtf",
             ["sgml"] = "text/sgml",
             ["sgm"] = "text/sgml",
             ["tsv"] = "text/tab-separated-values",

--- a/src/MimeTypesMap/MimeTypesMap.cs
+++ b/src/MimeTypesMap/MimeTypesMap.cs
@@ -888,6 +888,7 @@ namespace HeyRed.Mime
             ["in"] = "text/plain",
             ["dsc"] = "text/prs.lines.tag",
             ["rtx"] = "text/richtext",
+			["rtf"] = "text/rtf",
             ["sgml"] = "text/sgml",
             ["sgm"] = "text/sgml",
             ["tsv"] = "text/tab-separated-values",


### PR DESCRIPTION
currently .rtf extension is mapped as "application/text", but there is the mime type "text/rtf" that is not mapped so it has been identified as .bin