### PR TITLE
Add support to get a list of extensions

### DIFF
--- a/src/MimeTypesMap/MimeTypesMap.cs
+++ b/src/MimeTypesMap/MimeTypesMap.cs
@@ -1015,7 +1015,7 @@ namespace HeyRed.Mime
             {
                 return ext;
             }
-            return new List<string> { "???" };
+            return new List<string> { _defaultExtension };
         }
 
         public static string GetMimeType(string fileName)

--- a/src/MimeTypesMap/MimeTypesMap.cs
+++ b/src/MimeTypesMap/MimeTypesMap.cs
@@ -1008,6 +1008,16 @@ namespace HeyRed.Mime
             return _defaultExtension;
         }
 
+        public static IEnumerable<string> GetExtensions(string mime)
+        {
+            var ext = _mimeTypeMap.Value.Where(x => x.Value.Contains(mime)).Select(x => x.Key);
+            if (ext != null)
+            {
+                return ext;
+            }
+            return new List<string> { "???" };
+        }
+
         public static string GetMimeType(string fileName)
         {
             string ext = fileName;

--- a/src/MimeTypesMap/MimeTypesMap.tt
+++ b/src/MimeTypesMap/MimeTypesMap.tt
@@ -38,6 +38,16 @@ namespace HeyRed.Mime
             return _defaultExtension;
         }
 
+        public static IEnumerable<string> GetExtensions(string mime)
+        {
+            var ext = _mimeTypeMap.Value.Where(x => x.Value.Contains(mime)).Select(x => x.Key);
+            if (ext != null)
+            {
+                return ext;
+            }
+            return new List<string> { "???" };
+        }
+
         public static string GetMimeType(string fileName)
         {
             string ext = fileName;

--- a/src/MimeTypesMap/MimeTypesMap.tt
+++ b/src/MimeTypesMap/MimeTypesMap.tt
@@ -45,7 +45,7 @@ namespace HeyRed.Mime
             {
                 return ext;
             }
-            return new List<string> { "???" };
+            return new List<string> { _defaultExtension };
         }
 
         public static string GetMimeType(string fileName)

--- a/test/MimeTypesMapTests/SimpleTests.cs
+++ b/test/MimeTypesMapTests/SimpleTests.cs
@@ -1,4 +1,5 @@
-﻿using HeyRed.Mime;
+﻿using System.Collections.Generic;
+using HeyRed.Mime;
 using Xunit;
 
 namespace MimeTypesMapTests
@@ -31,6 +32,19 @@ namespace MimeTypesMapTests
         {
             var ext = MimeTypesMap.GetExtension("image/jpeg");
             Assert.Equal("jpeg", ext);
+        }
+
+        [Fact]
+        public void GetExtensions()
+        {
+            var expected = new List<string>
+            {
+                "ai",
+                "eps",
+                "ps"
+            };
+            var exts = MimeTypesMap.GetExtensions("application/postscript");
+            Assert.Equal(expected, exts);
         }
         
         [Fact]


### PR DESCRIPTION
It would be nice to be able to get a list of all possible extensions based on mime type. This PR add a new method that will return all matched extensions instead of just the first extension.